### PR TITLE
Update lang_french.php

### DIFF
--- a/lang_french.php
+++ b/lang_french.php
@@ -8,7 +8,7 @@ define("ABI_UI_WELCOME_HEADER_REGISTER", "Créer un compte");
 define("ABI_UI_WELCOME_INFO_NOACCOUNT", "Pas encore un membre d'ABI?");
 define("ABI_UI_WELCOME_INFO_PWRESET", "Entrer votre email pour réinitialiser votre mot de passe");
 define("ABI_UI_WELCOME_INFO_CREATE", "Entrer vos informations pour créer un compte. Votre nom d'utilisateur peut seulement contenir [a-z] [A-Z] [0-9] [.-_]");
-define("ABI_UI_WELCOME_INFO_AGREEBOX", "Je suis d'accord avec le");
+define("ABI_UI_WELCOME_INFO_AGREEBOX", "J'accepte");
 
 define("ABI_UI_WELCOME_HEADER_PWRESET_SENT", "Requête envoyée!");
 define("ABI_UI_WELCOME_INFO_PWRESET_SENT", "Si cet email est connu de notre côté, vous recevrez un email sous peu."); 

--- a/lang_french.php
+++ b/lang_french.php
@@ -7,26 +7,26 @@ define("ABI_UI_WELCOME_HEADER_REGISTER", "Créer un compte");
 
 define("ABI_UI_WELCOME_INFO_NOACCOUNT", "Pas encore un membre d'ABI?");
 define("ABI_UI_WELCOME_INFO_PWRESET", "Entrer votre email pour réinitialiser votre mot de passe");
-define("ABI_UI_WELCOME_INFO_CREATE", "Entrer vos informations pour créer un compte");
+define("ABI_UI_WELCOME_INFO_CREATE", "Entrer vos informations pour créer un compte. Votre nom d'utilisateur peut seulement contenir [a-z] [A-Z] [0-9] [.-_]");
 define("ABI_UI_WELCOME_INFO_AGREEBOX", "Je suis d'accord avec le");
 
 define("ABI_UI_WELCOME_HEADER_PWRESET_SENT", "Requête envoyée!");
-define("ABI_UI_WELCOME_INFO_PWRESET_SENT", "Si cet email est connu de notre côté, vous recevrez un email dans pas longtemps."); 
+define("ABI_UI_WELCOME_INFO_PWRESET_SENT", "Si cet email est connu de notre côté, vous recevrez un email sous peu."); 
 
-define("ABI_UI_WELCOME_HEADER_PWRESET_COMPLETE", "Réinitialisation du mot de passe traité!");
-define("ABI_UI_WELCOME_INFO_PWRESET_COMPLETE", "La réinitialisation de votre mot de passe a été traité et votre mot de passe a été changé.");
+define("ABI_UI_WELCOME_HEADER_PWRESET_COMPLETE", "Réinitialisation du mot de passe traitée!");
+define("ABI_UI_WELCOME_INFO_PWRESET_COMPLETE", "La réinitialisation de votre mot de passe a été traitée et votre mot de passe a été changé.");
 
-define("ABI_UI_WELCOME_HEADER_PW_NO_MATCH", "Vos mots de passes ne correspondent pas!");
-define("ABI_UI_WELCOME_INFO_PW_NO_MATCH", "Vos mots de passes saisis ne correspondent pas.");
+define("ABI_UI_WELCOME_HEADER_PW_NO_MATCH", "Vos mots de passe ne correspondent pas!");
+define("ABI_UI_WELCOME_INFO_PW_NO_MATCH", "Les mots de passe saisis ne correspondent pas.");
 
 define("ABI_UI_WELCOME_HEADER_PW_TOO_WEAK", "Mot de passe trop faible!");
-define("ABI_UI_WELCOME_INFO_PW_TOO_WEAK", "Votre mot de pass est trop faible. Pour votre sécurité, veuillez utiliser un mot de passe plus fort.");
+define("ABI_UI_WELCOME_INFO_PW_TOO_WEAK", "Votre mot de passe est trop faible. Pour votre sécurité, veuillez utiliser un mot de passe plus robuste.");
 
 define("ABI_UI_WELCOME_HEADER_EMAIL_INVALID", "Adresse email invalide!");
-define("ABI_UI_WELCOME_INFO_EMAIL_INVALID", "L'adresse emaile saisie n'est pas valide. Veuillez vérifier si vous avez commis des typos.");
+define("ABI_UI_WELCOME_INFO_EMAIL_INVALID", "L'adresse email saisie n'est pas valide. Veuillez vérifier si vous avez fait des fautes de frappe.");
 
 define("ABI_UI_WELCOME_HEADER_ACCOUNT_AWAIT_CONFIRM", "Bienvenue chez ABI!");
-define("ABI_UI_WELCOME_INFO_ACCOUNT_AWAIT_CONFIRM", "Votre compte utilisateur a été créé et est maintenant en attente de confirmation. Veuillez vérifier votre boite mail, ainsi que vos dossiers spams et promotions.");
+define("ABI_UI_WELCOME_INFO_ACCOUNT_AWAIT_CONFIRM", "Votre compte utilisateur a été créé et est maintenant en attente de confirmation. Veuillez vérifier votre boîte email, ainsi que vos dossiers spams et promotions.");
 
 define("ABI_UI_WELCOME_HEADER_ACCOUNT_CONFIRMED", "Bienvenue chez ABI!");
 define("ABI_UI_WELCOME_INFO_ACCOUNT_CONFIRMED", "Votre compte a été activé et vous pouvez maintenant vous connecter.");
@@ -35,46 +35,46 @@ define("ABI_UI_WELCOME_HEADER_REGISTER_DISABLED", "Les inscriptions sont désact
 define("ABI_UI_WELCOME_INFO_REGISTER_DISABLED", "Les inscriptions sont en ce moment désactivées.");
 
 define("ABI_UI_WELCOME_HEADER_LOGIN_DISABLED", "Les connexions sont désactivées!");
-define("ABI_UI_WELCOME_INFO_LOGIN_DISABLED", "Les connexions sont en ce moment désactivées.");
+define("ABI_UI_WELCOME_INFO_LOGIN_DISABLED", "Les connexions sont désactivées pour le moment.");
 
 define("ABI_UI_WELCOME_HEADER_LEGAL_CHECKBOXES", "Conditions légales requises non remplies!");
 define("ABI_UI_WELCOME_INFO_LEGAL_CHECKBOXES", "Pour créer un compte, vous devez accepter nos directives et politique de confidentialité!");
 
 define("ABI_UI_WELCOME_HEADER_SECURITY_CSRF", "Session d'inscription expirée!");
-define("ABI_UI_WELCOME_INFO_SECURITY_CSRF", "Le processus d'inscription a pris trop de temps. Veuillez rafraichir la page et essayer de nouveau.");
+define("ABI_UI_WELCOME_INFO_SECURITY_CSRF", "Le processus d'inscription a pris trop de temps. Veuillez rafraîchir la page et réessayer.");
 
 define("ABI_UI_WELCOME_HEADER_CONFIRM_TOKEN_UNKNOWN", "Jeton de confirmation inconnu!");
-define("ABI_UI_WELCOME_INFO_CONFIRM_TOKEN_UNKNOWN", "Jeton d'activation invalide. Veuillez faire en sorte d'utiliser le lien envoyé via email ou contactez le support ABI.");
+define("ABI_UI_WELCOME_INFO_CONFIRM_TOKEN_UNKNOWN", "Jeton d'activation invalide. Veuillez vous assurer d'utiliser le lien envoyé par email ou contactez le support ABI.");
 
 define("ABI_UI_WELCOME_HEADER_USER_ILLEGAL", "Nom d'utilisateur non autorisé!");
-define("ABI_UI_WELCOME_INFO_USER_ILLEGAL", "Le non d'utilisateur que vous avez spécifié est illégal et ne peut être utilisé. Les nom d'utilisateurs ne peuvent contenir que des caractères alphanumériques, des signes moins, des traits de soulignement et des nombres.");
+define("ABI_UI_WELCOME_INFO_USER_ILLEGAL", "Le nom d'utilisateur que vous avez spécifié est illégal et ne peut être utilisé. Les noms d'utilisateurs ne peuvent contenir que des caractères alphanumériques, des signes moins, des tirets bas, des points et des nombres.");
 
 define("ABI_UI_WELCOME_HEADER_USER_TAKEN", "Nom d'utilisateur déjà pris!");
 define("ABI_UI_WELCOME_INFO_USER_TAKEN", "Le nom d'utilisateur que vous avez spécifié est déjà utilisé. Veuillez choisir un autre nom.");
 
 define("ABI_UI_WELCOME_HEADER_EMAIL_TAKEN", "Email déjà pris!");
-define("ABI_UI_WELCOME_INFO_EMAIL_TAKEN", "Un autre compte utilisateur a déjà été enregistré en utilisant cette adresse email.");
+define("ABI_UI_WELCOME_INFO_EMAIL_TAKEN", "Un autre compte utilisateur utilisant cette adresse email a déjà été enregistré.");
 
 define("ABI_UI_WELCOME_HEADER_CREDS_INVALID", "Identifiants invalides fournis");
 define("ABI_UI_WELCOME_INFO_CREDS_INVALID", "Identifiants de connexion invalides entrés! Envoyez un message à team@abinteractive.net pour plus d'aide.");
 
 define("ABI_UI_WELCOME_HEADER_CONFIRM_PENDING", "Compte non activé!");
-define("ABI_UI_WELCOME_INFO_CONFIRM_PENDING", "Votre compte est actuellement en attente de confirmation. Vous pouvez renvoyer votre courrier de confirmation en cliquant sur le bouton ci-dessous.");
-define("ABI_UI_WELCOME_BUTTON_CONFIRM_PENDING", "Renvoyer le courrier de confirmation");
+define("ABI_UI_WELCOME_INFO_CONFIRM_PENDING", "Votre compte est actuellement en attente de confirmation. Vous pouvez renvoyer votre email de confirmation en cliquant sur le bouton ci-dessous.");
+define("ABI_UI_WELCOME_BUTTON_CONFIRM_PENDING", "Renvoyer l'email de confirmation");
 
 define("ABI_UI_WELCOME_HEADER_CONFIRM_RESENT", "Requête envoyée!");
-define("ABI_UI_WELCOME_INFO_CONFIRM_RESENT", "Votre courrier de confirmation a été renvoyé. Veuillez vérifier vos dossier de spams et promotions.");
+define("ABI_UI_WELCOME_INFO_CONFIRM_RESENT", "Votre email de confirmation a été renvoyé. Veuillez vérifier vos dossier de spams et promotions.");
 
 define("ABI_UI_WELCOME_PLACEHOLDER_USER", "Nom d'utilisateur");
 define("ABI_UI_WELCOME_PLACEHOLDER_EMAIL", "Email");
 define("ABI_UI_WELCOME_PLACEHOLDER_PASSWORD", "Mot de passe");
-define("ABI_UI_WELCOME_PLACEHOLDER_PASSWORDCONFIRM", "Confirmer le mot de passe");
+define("ABI_UI_WELCOME_PLACEHOLDER_PASSWORDCONFIRM", "Confirmer votre mot de passe");
 
 define("ABI_UI_WELCOME_BUTTON_SIGNIN", "Se connecter");
 define("ABI_UI_WELCOME_BUTTON_SIGNUP", "S'enregistrer");
-define("ABI_UI_WELCOME_BUTTON_RESETPW", "Réinitialiser le mot de passe");
+define("ABI_UI_WELCOME_BUTTON_RESETPW", "Réinitialiser votre mot de passe");
 define("ABI_UI_WELCOME_BUTTON_RESETPWSUBMIT", "Demander une réinitialisation");
 define("ABI_UI_WELCOME_BUTTON_BACKTOLOGIN", "Retour à la page d'identification");
 
-define("ABI_UI_WELCOME_BOX_TERMS", "Termes & Directives");
+define("ABI_UI_WELCOME_BOX_TERMS", "Conditions & Directives");
 define("ABI_UI_WELCOME_BOX_PRIVACY", "Politique de confidentialité");


### PR DESCRIPTION
Changes: 
spell checking, terminology standardization ("email" is now the only word used instead of 3 different words), informal words replaced, matching content of some sentences (ex: line 10 missing half of the English version).

more specific:
- line 11 cannot match line 79 and 80. "the" can be both singular and plural in English but there is no perfect match for it in French. Plural is needed for line 79 ("J'accepte **les**") and singular is needed for line 80 ("J'accepte **la**"). I chose to not use any of them to avoid confusion and went with "J'accepte"("I agree") instead.